### PR TITLE
chore: .agents/skills/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ node_modules
 logs
 *.log
 
+# Skills (managed by skills.sh)
+.agents/skills/
+
 # Misc
 .DS_Store
 .fleet


### PR DESCRIPTION
## Summary

- `skills.sh` で管理される `.agents/skills/` ディレクトリを `.gitignore` に追加
- `node_modules` 同様、コマンドで更新・管理されるため git 追跡不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)